### PR TITLE
依存するAlamofireのバージョンを5.9.0に修正

### DIFF
--- a/AlamofireObjectMapper.podspec
+++ b/AlamofireObjectMapper.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.source_files = 'AlamofireObjectMapper/**/*.swift'
-  s.dependency 'Alamofire', '5.8.1'
+  s.dependency 'Alamofire', '5.9.0'
   s.dependency 'ObjectMapper', '4.2.0'
 end


### PR DESCRIPTION
[Alamofire 5.9.0](https://github.com/Alamofire/Alamofire/releases/tag/5.9.0)でPrivacyInfoファイルが追加されたため、依存バージョンを5.9.0にします。